### PR TITLE
Fix: Static SSVEP Page

### DIFF
--- a/src/ezmsg/tasks/ssvep/stimulus.py
+++ b/src/ezmsg/tasks/ssvep/stimulus.py
@@ -53,8 +53,10 @@ class SSVEPStimulus(CanvasStimulus):
         """,
 
         "design_stimulus": """
-            state.width = stimulus_el.width;
-            state.height = stimulus_el.height;
+            stimulus_el.width = model.width;
+            stimulus_el.height = model.height;
+            state.width = model.width;
+            state.height = model.height;
             state.ctx.clearRect(0, 0, state.width, state.height);
 
             // Assumption: state.id_a.data and state.id_b.data have the same length
@@ -93,6 +95,11 @@ class SSVEPStimulus(CanvasStimulus):
         """,
 
         "draw": """
+            if (data.period_ms != state.period || state.width != stimulus_el.width || state.height != stimulus_el.height){
+                self.reschedule();
+                self.design_stimulus();
+            }
+
             state.ctx.clearRect(0, 0, state.width, state.height);
             if(data.presented) {
                 state.ctx.putImageData(state.reverse ? state.id_a : state.id_b, 0, 0);


### PR DESCRIPTION
The current existing SSVEP task in the main branch works really well ... so long as only one client has been served the page...

It turns out Panel has issues serving multiple clients the same models.  Most of the time, I believe Panel will clone widgets to serve them to multiple clients, but something weird happens if you dynamically adjust models that are already served to multiple clients.  This is possibly an issue with FastListTemplate?

This PR is a significant down-grade to the current SSVEP task to make all models and content static on the page to avoid dynamically adjusting a page that's already been served to multiple clients.  As a result, this results in a lot LESS functionality than the previous task had.  

But it shouldn't crash if multiple clients are viewing and editing the same models.  So that's good I guess.